### PR TITLE
Filament 4 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ features to your password inputs:
 
 ## Installation
 
-> Upgrading to 2.0 from 1.x? Be sure to follow the [Upgrade](https://github.com/rawilk/filament-password-input/blob/main/upgrade.md) guide for breaking changes.
+> Upgrading to 3.0 from 2.x? Be sure to follow the [Upgrade](https://github.com/rawilk/filament-password-input/blob/main/upgrade.md) guide for breaking changes.
 
 You can install the package via composer:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade Guide
 
+## Upgrade to 3.0 from 2.x
+
+### Breaking changes
+* This package now requires [Filament](https://filamentphp.com) 4.0 or greater.
+* This package now requires Laravel 11 or greater.
+
+
 ## Upgrading to 2.0 from 1.x
 
 I've attempted to document every breaking change, however I may have missed some. If you're having an issue upgrading, please raise an issue and/or PR an update to the upgrade guide if applicable.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,16 @@
 ### Breaking changes
 * This package now requires [Filament](https://filamentphp.com) 4.0 or greater.
 * This package now requires Laravel 11 or greater.
+* Change the `copyable()` method parameters to align with the new Filament copyable method:
+```php
+Password::make()
+    ->copyable(
+        condition: true,
+        copyMessage: 'Copied',
+        copyMessageDuration: 2000,
+        color: 'primary',
+    ),
+```
 
 
 ## Upgrading to 2.0 from 1.x

--- a/composer.json
+++ b/composer.json
@@ -20,18 +20,18 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "filament/forms": "^3.2",
-        "illuminate/contracts": "^10.0|^11.0|^12.0",
+        "php": "^8.2",
+        "filament/forms": "^4.0",
+        "illuminate/contracts": "^11.0|^12.0",
         "spatie/laravel-package-tools": "^1.14"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9|^8.0",
-        "orchestra/testbench": "^8.8|^9.0|^10.0",
-        "pestphp/pest": "^2.20|^3.7",
-        "pestphp/pest-plugin-laravel": "^2.2|^3.1",
-        "pestphp/pest-plugin-livewire": "^2.1|^3.0",
+        "nunomaduro/collision": "^8.0",
+        "orchestra/testbench": "^9.0|^10.0",
+        "pestphp/pest": "^3.7",
+        "pestphp/pest-plugin-laravel": "^3.1",
+        "pestphp/pest-plugin-livewire": "^3.0",
         "spatie/laravel-ray": "^1.31"
     },
     "autoload": {

--- a/src/Actions/CopyToClipboardAction.php
+++ b/src/Actions/CopyToClipboardAction.php
@@ -7,6 +7,7 @@ namespace Rawilk\FilamentPasswordInput\Actions;
 use Filament\Actions\Action;
 use Filament\Schemas\Components\Component;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Js;
 
 class CopyToClipboardAction extends Action
@@ -17,7 +18,7 @@ class CopyToClipboardAction extends Action
 
         $this->label(__('filament-password-input::password.actions.copy.tooltip'));
 
-        $this->icon(FilamentIcon::resolve('filament-password-input::copy') ?? 'heroicon-m-clipboard');
+        $this->icon(FilamentIcon::resolve('filament-password-input::copy') ?? Heroicon::OutlinedClipboardDocument);
 
         $this->color('gray');
 

--- a/src/Actions/CopyToClipboardAction.php
+++ b/src/Actions/CopyToClipboardAction.php
@@ -8,8 +8,6 @@ use Filament\Actions\Action;
 use Filament\Schemas\Components\Component;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Support\Js;
-use Rawilk\FilamentPasswordInput\Concerns\CanCopyToClipboard;
-use Rawilk\FilamentPasswordInput\Concerns\CanRegeneratePassword;
 
 class CopyToClipboardAction extends Action
 {
@@ -61,6 +59,7 @@ class CopyToClipboardAction extends Action
             return true;
         }
 
-        return $this->isDisabled();
+        return $this->getSchemaComponent()->isDisabled() ||
+            $this->getSchemaComponent()->isReadOnly();
     }
 }

--- a/src/Actions/CopyToClipboardAction.php
+++ b/src/Actions/CopyToClipboardAction.php
@@ -8,6 +8,8 @@ use Filament\Actions\Action;
 use Filament\Schemas\Components\Component;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Support\Js;
+use Rawilk\FilamentPasswordInput\Concerns\CanCopyToClipboard;
+use Rawilk\FilamentPasswordInput\Concerns\CanRegeneratePassword;
 
 class CopyToClipboardAction extends Action
 {
@@ -59,6 +61,6 @@ class CopyToClipboardAction extends Action
             return true;
         }
 
-        return $this->getComponent()->isDisabled();
+        return $this->isDisabled();
     }
 }

--- a/src/Actions/CopyToClipboardAction.php
+++ b/src/Actions/CopyToClipboardAction.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Rawilk\FilamentPasswordInput\Actions;
 
-use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Components\Component;
+use Filament\Actions\Action;
+use Filament\Schemas\Components\Component;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Support\Js;
 

--- a/src/Actions/RegeneratePasswordAction.php
+++ b/src/Actions/RegeneratePasswordAction.php
@@ -10,6 +10,7 @@ use Filament\Actions\Concerns\CanCustomizeProcess;
 use Filament\Schemas\Components\Component;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Facades\FilamentIcon;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Str;
 
 class RegeneratePasswordAction extends Action
@@ -26,7 +27,7 @@ class RegeneratePasswordAction extends Action
 
         $this->label(__('filament-password-input::password.actions.regenerate.tooltip'));
 
-        $this->icon(FilamentIcon::resolve('filament-password-input::regenerate') ?? 'heroicon-o-key');
+        $this->icon(FilamentIcon::resolve('filament-password-input::regenerate') ?? Heroicon::OutlinedKey);
 
         $this->color('gray');
 

--- a/src/Actions/RegeneratePasswordAction.php
+++ b/src/Actions/RegeneratePasswordAction.php
@@ -79,7 +79,7 @@ class RegeneratePasswordAction extends Action
             return true;
         }
 
-        return $this->getComponent()->isDisabled() ||
-            $this->getComponent()->isReadOnly();
+        return $this->getSchemaComponent()->isDisabled() ||
+            $this->getSchemaComponent()->isReadOnly();
     }
 }

--- a/src/Actions/RegeneratePasswordAction.php
+++ b/src/Actions/RegeneratePasswordAction.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Rawilk\FilamentPasswordInput\Actions;
 
 use Closure;
+use Filament\Actions\Action;
 use Filament\Actions\Concerns\CanCustomizeProcess;
-use Filament\Forms\Components\Actions\Action;
-use Filament\Forms\Components\Component;
-use Filament\Forms\Set;
+use Filament\Schemas\Components\Component;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Support\Facades\FilamentIcon;
 use Illuminate\Support\Str;
 

--- a/src/Concerns/CanCopyToClipboard.php
+++ b/src/Concerns/CanCopyToClipboard.php
@@ -18,8 +18,13 @@ trait CanCopyToClipboard
 
     public function copyable(
         bool|Closure $condition = true,
+        string|Closure|null $copyMessage = null,
+        int|Closure|null $copyMessageDuration = null,
         string|array|Closure|null $color = null,
     ): static {
+        $this->copyMessage = $copyMessage;
+        $this->copyMessageDuration = $copyMessageDuration;
+
         $action = CopyToClipboardAction::make()->visible($condition);
 
         if ($color) {

--- a/src/Concerns/CanRegeneratePassword.php
+++ b/src/Concerns/CanRegeneratePassword.php
@@ -8,7 +8,7 @@ use Closure;
 use Rawilk\FilamentPasswordInput\Actions\RegeneratePasswordAction;
 
 /**
- * @mixin \Filament\Forms\Components\Component
+ * @mixin \Filament\Schemas\Components\Component
  */
 trait CanRegeneratePassword
 {


### PR DESCRIPTION
* This package now requires [Filament](https://filamentphp.com) 4.0 or greater.
* This package now requires Laravel 11 or greater.
* Change the `copyable()` method parameters to align with the new Filament copyable method:
```php
Password::make()
    ->copyable(
        condition: true,
        copyMessage: 'Copied',
        copyMessageDuration: 2000,
        color: 'primary',
    ),
```